### PR TITLE
chore: add .catalog/catalog-info.yaml

### DIFF
--- a/.catalog/catalog-info.yaml
+++ b/.catalog/catalog-info.yaml
@@ -1,0 +1,39 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: harbor-scanner-trivy
+  title: Harbor Scanner Trivy
+  description: Harbor scanner adapter fork，用于为 Harbor 2.14 版本集成基于 Trivy 的漏洞扫描能力。
+  annotations:
+    # github plugin
+    github.com/project-slug: AlaudaDevops/harbor-scanner-trivy
+    # 开源组件代码仓库地址，格式：${url}/${project}/${repo}
+    acp.cpaas.io/open-source-component-repo: https://github.com/goharbor/harbor-scanner-trivy
+    # 开源组件的版本信息，只适用于开源组件，自研组件默认不收集版本信息,格式 ${version}
+    acp.cpaas.io/open-source-component-version: v0.34.2
+    # 开源组件的license信息,格式 ${license}
+    acp.cpaas.io/open-source-component-license: Apache-2.0
+    # 开源组件的license地址,格式 ${url}/${project}/${repo}/${license-path}
+    acp.cpaas.io/open-source-component-license_url: https://github.com/goharbor/harbor-scanner-trivy/blob/main/LICENSE
+    # backstage techdocs plugin
+    backstage.io/techdocs-ref: dir:.
+    acp.cpaas.io/owner: jtcheng@alauda.io
+
+    acp.cpaas.io/functional-attributes: plugin
+spec:
+  type: service
+  system: system:devops-tools
+  lifecycle: production
+  owner: devops
+---
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: devops-tools
+  title: Devops Tools
+  tags:
+  - golang
+  - devops
+spec:
+  owner: devops
+  domain: devops


### PR DESCRIPTION
## Summary
- add .catalog/catalog-info.yaml for Backstage catalog registration
- keep the source-of-truth component metadata with the repository

## Testing
- yaml parse check
